### PR TITLE
Handle unexpected redis error on setup

### DIFF
--- a/main.go
+++ b/main.go
@@ -282,6 +282,12 @@ func main() {
 
 			secret = hex.EncodeToString(key)
 			rdb.Set(c.Context(), "secrets:"+hash(PEPPER_SECRETS+userId), secret, 0)
+		} else if err != nil {
+			// Print out the error message so we can debug it
+			fmt.Println(err)
+			return c.Status(500).JSON(&fiber.Map{
+				"error": "Failed to get secret",
+			})
 		}
 
 		return c.JSON(&fiber.Map{

--- a/main.go
+++ b/main.go
@@ -283,11 +283,7 @@ func main() {
 			secret = hex.EncodeToString(key)
 			rdb.Set(c.Context(), "secrets:"+hash(PEPPER_SECRETS+userId), secret, 0)
 		} else if err != nil {
-			// Print out the error message so we can debug it
-			fmt.Println(err)
-			return c.Status(500).JSON(&fiber.Map{
-				"error": "Failed to get secret",
-			})
+			panic(err)
 		}
 
 		return c.JSON(&fiber.Map{


### PR DESCRIPTION
Currently if there is an issue with the redis connection the backend will just send the client an empty secret. This throws an error on the client and was a bit hard to diagnose. 

This PR will handle that error and log it as well as pass a generic error message to the client. 