### PR TITLE
Document environment variables better :)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ up to you to manage.
   - `REDIS_URI` should be changed to `redis:6379`.
   - `ROOT_REDIRECT` should be changed to whatever you want the `/` of the API to be set to a different site,
     like your own personal homepage.
-  - `DISCORD_*` should be configured with your Discord application.
+  - `DISCORD_*` should be configured with your Discord application. The redirect URI is `https://<yourdomain>/v1/oauth/callback`.
   - `PEPPER_*` should be unique values. These provide extra anonymity and make it more difficult to get user
-    info. It [is recommended](https://stackoverflow.com/a/9622855) you use at least 32 bytes of randomness, e.g. through `openssl rand 32 -hex`
+    info. It [is recommended](https://stackoverflow.com/a/9622855) you use at least 32 bytes of randomness, e.g. through `openssl rand 32 -hex`.
   - `SIZE_LIMIT` is up to you, but should usually be left as default. This is for the settings sync and how
     much data a user can store.
 4. Create a `docker-compose.override.yml` that maps your ports, like so:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ up to you to manage.
     like your own personal homepage.
   - `DISCORD_*` should be configured with your Discord application.
   - `PEPPER_*` should be unique values. These provide extra anonymity and make it more difficult to get user
-    info.
+    info. It [is recommended](https://stackoverflow.com/a/9622855) you use at least 32 bytes of randomness, e.g. through `openssl rand 32 -hex`
   - `SIZE_LIMIT` is up to you, but should usually be left as default. This is for the settings sync and how
     much data a user can store.
 4. Create a `docker-compose.override.yml` that maps your ports, like so:


### PR DESCRIPTION
While setting up the instance I had to dig through the code a bit to find answers on what to use as salt size & redirect URI, I think documenting those might be a good idea :D