### PR TITLE
fix: restrict CORS allowed origins

### DIFF
--- a/main.go
+++ b/main.go
@@ -142,6 +142,7 @@ func main() {
 
 	app.Use(cors.New(cors.Config{
 		ExposeHeaders: "ETag",
+        AllowOrigins: "https://discord.com,https://ptb.discord.com,https://canary.discord.com",
 	}))
 	app.Use(logger.New())
 


### PR DESCRIPTION
Restricts CORS allowed origins to Discord domains.

Not sure if there are any more domains needed to be whitelisted (`discordapp.com`?)