### PR TITLE
Add more files to `.dockerignore`

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,27 @@
+# os related
+.DS_Store
+Thumbs.db
+
+# editors
 .vscode/
+.idea/
+.fleet/
+
+# secrets
 .env
+
+# Docker
+docker-compose.yml
+docker-compose.*.yml
+Dockerfile
+redis-data/ # redis data mountpoint from docker-compose.yml
+
+# git
+.git/
+.gitignore
+.gitattributes
+
+# binaries
+backend
+Backend
+Backend.exe


### PR DESCRIPTION
Added a few more files to `.dockerignore` to prevent useless cache-miss scenarios. Also labelled the sections for easier skimming.

This shouldn't impact the final build result in any way.

Reasoning:
- `os related`: Useless os-specific metadata
- `editors`: Added `.idea` for JetBrains products, and `.fleet` for JetBrains Fleet
- `Docker`: Docker builds don't need to know about how they're built. Changing a port mapping also shouldn't have to trigger a rebuild of the application. It also somewhat helps with security because secrets stored in eg. `docker-compose.override.yml` aren't presented to the application at build time.
- `git`: The build doesn't need (and shouldn't) know/care about the VCS it uses. If some attributes are needed at runtime in the future (eg. as part of version string) they can be exposed via Docker build args
- `binaries`: The whole point of the docker setup is to generate a clean binary to run. If someone generated some artefacts already, it doesn't really mean anything to the build aside from busting caches.