### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ up to you to manage.
    services:
      backend:
        ports:
-         - HOST_PORT:8080
+         - "8080:8080"
    ```
-5. `docker compose up -d`
+5. `docker-compose up -d`
 
 Please note that, due to mixed content requirements, you will need HTTPS on your self-hosted instance.


### PR DESCRIPTION
Changes:
1. Add a missing dash at step 5
2. Modified step 4 ports to `- "8080:8080"` from `- HOST_PORT:8080` because docker-compose was throwing error saying it's an invalid type