### PR TITLE
Support portainer

### DIFF
--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -1,0 +1,29 @@
+version: "3.1"
+
+services:
+    redis:
+        image: redis:alpine
+        restart: always
+        volumes:
+            - ./redis-data:/data
+        environment:
+            REDIS_ARGS: --save 300 1 60 10
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 5s
+            timeout: 5s
+            retries: 5
+
+    backend:
+        image: vencord/backend
+        build: .
+        restart: always
+        env_file:
+            - stack.env
+        depends_on:
+            redis:
+                condition: service_healthy
+        environment:
+            PORT: 8080
+        ports:
+            - ${PORT}:8080/tcp

--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -25,5 +25,6 @@ services:
                 condition: service_healthy
         environment:
             PORT: 8080
+            REDIS_URI: redis:6379
         ports:
             - ${PORT}:8080/tcp

--- a/docker-compose-portainer.yml
+++ b/docker-compose-portainer.yml
@@ -25,6 +25,7 @@ services:
                 condition: service_healthy
         environment:
             PORT: 8080
+            HOST: 0.0.0.0
             REDIS_URI: redis:6379
         ports:
             - ${PORT}:8080/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,5 +34,6 @@ services:
             SIZE_LIMIT: ${SIZE_LIMIT}
             ALLOWED_USERS: ${ALLOWED_USERS}
             PROMETHEUS: ${PROMETHEUS}
+            PROXY_HEADER: ${PROXY_HEADER}
         ports:
             - ${PORT}:8080/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
             interval: 5s
             timeout: 5s
             retries: 5
+        hostname: redis
 
     backend:
         image: vencord/backend
@@ -24,6 +25,7 @@ services:
         environment:
             PORT: 8080
             HOST: ${HOST}
+            REDIS_URI: ${REDIS_URI}
             ROOT_REDIRECT: ${ROOT_REDIRECT}
             DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
             DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,17 @@ services:
         depends_on:
             redis:
                 condition: service_healthy
+        environment:
+            PORT: ${PORT}
+            HOST: ${HOST}
+            ROOT_REDIRECT: ${ROOT_REDIRECT}
+            DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
+            DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
+            DISCORD_REDIRECT_URI: ${DISCORD_REDIRECT_URI}
+            PEPPER_SECRETS: ${PEPPER_SECRETS}
+            PEPPER_SETTINGS: ${PEPPER_SETTINGS}
+            SIZE_LIMIT: ${SIZE_LIMIT}
+            ALLOWED_USERS: ${ALLOWED_USERS}
+            PROMETHEUS: ${PROMETHEUS}
+        ports:
+            ${PORT}:${PORT}/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,6 @@ services:
         image: vencord/backend
         build: .
         restart: always
-        env_file:
-            - .env
         depends_on:
             redis:
                 condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,4 +34,4 @@ services:
             ALLOWED_USERS: ${ALLOWED_USERS}
             PROMETHEUS: ${PROMETHEUS}
         ports:
-            ${PORT}:${PORT}/tcp
+            - ${PORT}:${PORT}/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
             redis:
                 condition: service_healthy
         environment:
-            PORT: ${PORT}
+            PORT: 8080
             HOST: ${HOST}
             ROOT_REDIRECT: ${ROOT_REDIRECT}
             DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
@@ -34,4 +34,4 @@ services:
             ALLOWED_USERS: ${ALLOWED_USERS}
             PROMETHEUS: ${PROMETHEUS}
         ports:
-            - ${PORT}:${PORT}/tcp
+            - ${PORT}:8080/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
             interval: 5s
             timeout: 5s
             retries: 5
-        hostname: redis
 
     backend:
         image: vencord/backend

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,22 +18,8 @@ services:
         image: vencord/backend
         build: .
         restart: always
+        env_file:
+            - .env
         depends_on:
             redis:
                 condition: service_healthy
-        environment:
-            PORT: 8080
-            HOST: ${HOST}
-            REDIS_URI: ${REDIS_URI}
-            ROOT_REDIRECT: ${ROOT_REDIRECT}
-            DISCORD_CLIENT_ID: ${DISCORD_CLIENT_ID}
-            DISCORD_CLIENT_SECRET: ${DISCORD_CLIENT_SECRET}
-            DISCORD_REDIRECT_URI: ${DISCORD_REDIRECT_URI}
-            PEPPER_SECRETS: ${PEPPER_SECRETS}
-            PEPPER_SETTINGS: ${PEPPER_SETTINGS}
-            SIZE_LIMIT: ${SIZE_LIMIT}
-            ALLOWED_USERS: ${ALLOWED_USERS}
-            PROMETHEUS: ${PROMETHEUS}
-            PROXY_HEADER: ${PROXY_HEADER}
-        ports:
-            - ${PORT}:8080/tcp


### PR DESCRIPTION
This PR basically just allows for the repo to be used in portainer.

Explained functionality: Create docker compose file specific for portainer. This file needs to be setup in the repository, or the users need to create their own forks of this project and maintain it. If an official image were published on an OCI repository there would be no need for this PR. 

Notes:
* `8080` is used in healthchecks so I've hardcoded the internal port to `8080`, `$PORT` now affects only the host port.