### PR TITLE
Fixing REDIS_URI in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 PORT=8080
 HOST=0.0.0.0
 # The URI used for connecting to redis
-REDIS_URI=localhost:6379
+REDIS_URI=redis:6379
 
 # URL that the root of the API will redirect to.
 # The site specified here HAS TO link to the source code (including your modificiations, if applicable),


### PR DESCRIPTION
Full credit to @Vendicated for the advice!

Since the redis server and the backend are two different containers, using localhost will not work. Updating to REDIS_URI=redis:6379 fixes this.

Apologies for the sloppy double-commit, this is my first time 🙃 Only reason why was to "update" the commit description with the Co-authored-by statement, to give credit to vee