### PR TITLE
Added Redis Password Input

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@ PORT=8080
 HOST=0.0.0.0
 # The URI used for connecting to redis
 REDIS_URI=redis:6379
+# The Password used for connecting to redis (leave blank if no password)
+REDIS_PASS=
 
 # URL that the root of the API will redirect to.
 # The site specified here HAS TO link to the source code (including your modificiations, if applicable),

--- a/globals/globals.go
+++ b/globals/globals.go
@@ -12,6 +12,7 @@ var (
 	PORT = os.Getenv("PORT")
 
 	REDIS_URI = os.Getenv("REDIS_URI")
+	REDIS_PASS = os.Getenv("REDIS_PASS")
 
 	ROOT_REDIRECT = os.Getenv("ROOT_REDIRECT")
 

--- a/main.go
+++ b/main.go
@@ -114,6 +114,7 @@ func main() {
 
 	g.RDB = redis.NewClient(&redis.Options{
 		Addr: g.REDIS_URI,
+		Password: g.REDIS_PASS,
 	})
 
 	if os.Getenv("PROMETHEUS") == "true" {

--- a/main.go
+++ b/main.go
@@ -81,6 +81,11 @@ func requireAuth(c *fiber.Ctx) error {
 			"error": "Invalid authorization",
 		})
 	} else if err != nil {
+		if err.Error() == "ERR invalid password" || err.Error() == "NOAUTH Authentication required." {
+			return c.Status(401).JSON(&fiber.Map{
+				"error": "Redis authentication failed",
+			})
+		}
 		panic(err)
 	}
 

--- a/routes/discord.go
+++ b/routes/discord.go
@@ -102,6 +102,11 @@ func GETOAuthCallback(c *fiber.Ctx) error {
 		secret = hex.EncodeToString(key)
 		g.RDB.Set(c.Context(), "secrets:"+util.Hash(g.PEPPER_SECRETS+userId), secret, 0)
 	} else if err != nil {
+		if err.Error() == "ERR invalid password" || err.Error() == "NOAUTH Authentication required." {
+			return c.Status(401).JSON(&fiber.Map{
+				"error": "Redis password is incorrect or missing!",
+			})
+		}
 		panic(err)
 	}
 


### PR DESCRIPTION
# Changelog

## Redis Allows Passwords
Allowed a redis password to be inputted into the bot, preventing an error lacking authentication. 

## File Changes

1. globals/globals.go
    - Added REDIS_PASS as variable
2. .env.example
    - Added REDIS_PASS as example variable
3. main.go
    - Added error for missing password to client console
4. routes/discord.go
    - Added error for missing password to client console
