### PR TITLE
Remove deprecated version in docker compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
     redis:
         image: redis:alpine


### PR DESCRIPTION
This minor change removes the deprecated `version` property from the Docker Compose file to avoid the warning when running it, aligning it with current best practices and recommendations.