### PR TITLE
Add support for arm host

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,13 +4,11 @@ on:
     push:
         branches:
             - main
-
         tags:
             - v*
-
         paths:
             - .github/workflows/build.yml
-            - '**/*.go'
+            - "**/*.go"
             - go.mod
             - go.sum
             - Dockerfile
@@ -32,7 +30,11 @@ jobs:
             id-token: write
 
         steps:
-            - uses: actions/checkout@v4
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v4
 
             - name: Set up Buildx
               uses: docker/setup-buildx-action@v3
@@ -55,6 +57,7 @@ jobs:
               uses: docker/build-push-action@v6
               with:
                   context: .
+                  platforms: linux/amd64,linux/arm64
                   push: true
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
ci: update GitHub Actions workflow for build process
- Adjusted paths to use double quotes for consistency.
- Added a step to set up QEMU for multi-platform builds.
- Specified platforms for Docker build to support both amd64 and arm64 architectures.