### PR TITLE
Add `ARM64`/`aarch64` Support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,9 @@ jobs:
 
         steps:
             - uses: actions/checkout@v4
+           
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v3           
 
             - name: Set up Buildx
               uses: docker/setup-buildx-action@v3
@@ -56,6 +59,7 @@ jobs:
               with:
                   context: .
                   push: true
+                  platforms: linux/amd64,linux/arm64
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,17 @@ FROM golang:1.23-alpine AS builder
 
 WORKDIR /app
 
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV CGO_ENABLED=0
+
 ADD go.mod go.sum ./
 RUN go mod download
 
 ADD . ./
-RUN go build -o backend
+
+RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o backend
 
 FROM alpine:latest
 


### PR DESCRIPTION
# Add ARM64/aarch64 Support

This PR adds support for building and running the application on ARM64 architecture devices, particularly Raspberry Pi systems. This enhancement broadens the project's compatibility and makes it more accessible to users with ARM-based systems.

## Changes

- [x] Modified Dockerfile to properly detect and build for ARM64/aarch64 architecture
- [x] Updated GitHub Actions workflow to build and publish multi-architecture images (amd64, arm64)